### PR TITLE
Update README.md

### DIFF
--- a/01-SetupEnvironment/README.md
+++ b/01-SetupEnvironment/README.md
@@ -40,7 +40,7 @@ The next step is add your linux user to the `docker` users group, so you will be
 
 After running this command, you will need to log out and log in again in your instance. When logging in again, run the following command to see if you are able to run a Docker container:
 
-    $ docker run hello-world
+    $ sudo docker run hello-world
 
 The output should look like:
 


### PR DESCRIPTION
The command must be running with sudo, if not an error ocurred.
`docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.37/containers/create: dial unix /var/run/docker.sock: connect: permission denied.
See 'docker run --help'.`